### PR TITLE
main: Use --limit-files

### DIFF
--- a/CoalaThread.py
+++ b/CoalaThread.py
@@ -62,7 +62,7 @@ class CoalaThread(threading.Thread):
         else:
             options.append('--find-config')
 
-        options.append('--files=%s' % self.file_name)
+        options.append('--limit-files=%s' % self.file_name)
         options.append('-S=autoapply=false')
         options.extend(self.extra_args)
         command.extend(options)


### PR DESCRIPTION
Earlier --files was being used but that wasn't the correct
option to be used because that replaces the files config value
only in [Default] section. This means that any other
section would clash with it.
Now we use the --limit-files argument which takes a subset
of all files with the glob provided in --limit-files. This ensures
that all sections with this file get executed and no clashes happen.